### PR TITLE
Support python 3 and add tests

### DIFF
--- a/jhashcode/__init__.py
+++ b/jhashcode/__init__.py
@@ -1,3 +1,5 @@
+import sys
+
 def _unknown_hash(_):
     raise TypeError('Unsupported type')
 
@@ -12,11 +14,18 @@ def hash_str_unicode(s):
 def hash_int(i):
     return i
 
-_TP_MAPPING = {
-    str: hash_str_unicode,
-    unicode: hash_str_unicode,
-    int: hash_int,
-}
+if int(sys.version[0]) > 2:
+    _TP_MAPPING = {
+        bytes: hash_str_unicode,
+        str: hash_str_unicode,
+        int: hash_int,
+    }
+else:
+    _TP_MAPPING = {
+        str: hash_str_unicode,
+        unicode: hash_str_unicode,
+        int: hash_int,
+    }
 
 
 def hashcode(o):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def descr():
 
 setup(
     name='jhashcode',
-    version='0.03',
+    version='0.4',
     author='Neuron Teckid',
     author_email='lene13@gmail.com',
     license='MIT',
@@ -18,6 +18,7 @@ setup(
     long_description=descr(),
     install_requires=[],
     zip_safe=False,
+    test_suite='tests',
     entry_points=dict(
         console_scripts=[],
     ),

--- a/tests/test_jhashcode.py
+++ b/tests/test_jhashcode.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+from jhashcode import hashcode
+
+class TestJHashCode(unittest.TestCase):
+
+    def test_empty_bytes(self):
+        self.assertEqual(hashcode(b''), 0)
+
+    def test_empty_unicode(self):
+        self.assertEqual(hashcode(u''), 0)
+
+    def test_unicode(self):
+        self.assertEqual(hashcode(u'者:s��2�*�=x�'), -1198738874)


### PR DESCRIPTION
I was attempting to use jhashcode in python 3 and I noticed that it wouldn't load due to some changes in the string typing betweeen python 2 and python 3.  Supporting both python 2 and python 3 at the same time turned out to be pretty straightforward.

I added a simple test suite to easily test against changes in the future.
